### PR TITLE
fix for camel 4.6 model changes

### DIFF
--- a/packages/camel-catalog/assembly/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaTest.java
+++ b/packages/camel-catalog/assembly/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaTest.java
@@ -36,6 +36,6 @@ public class CamelYamlDslSchemaTest extends CamelCatalogTestSupport {
         assertEquals(beansSchema.get("type").asText(), "array");
         var definitions = beansSchema.withObject("/definitions");
         assertEquals(1, definitions.size());
-        assertTrue(definitions.has("org.apache.camel.model.app.RegistryBeanDefinition"));
+        assertTrue(definitions.has("org.apache.camel.model.BeanFactoryDefinition"));
     }
 }

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessor.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessor.java
@@ -40,8 +40,6 @@ public class CamelYamlDslSchemaProcessor {
     private static final String PROPERTY_EXPRESSION_DEFINITION = "org.apache.camel.model.PropertyExpressionDefinition";
     private static final String ERROR_HANDLER_DEFINITION = "org.apache.camel.model.ErrorHandlerDefinition";
     private static final String ERROR_HANDLER_DESERIALIZER = "org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer";
-    private static final String ROUTE_TEMPLATE_BEAN_DEFINITION = "org.apache.camel.model.RouteTemplateBeanDefinition";
-    private static final String TEMPLATED_ROUTE_BEAN_DEFINITION = "org.apache.camel.model.TemplatedRouteBeanDefinition";
     private final ObjectMapper jsonMapper;
     private final ObjectNode yamlDslSchema;
     private final List<String> processorBlocklist = List.of(
@@ -550,26 +548,6 @@ public class CamelYamlDslSchemaProcessor {
             sanitizeDefinitions(yamlInFQCN, yamlInDefinition);
             answer.put(yamlInName, yamlInDefinition);
         }
-        return answer;
-    }
-
-    public ObjectNode getRouteTemplateBean() {
-        var definitions = yamlDslSchema
-                .withObject("/items")
-                .withObject("/definitions");
-        var relocatedDefinitions = relocateToRootDefinitions(definitions);
-        var answer = relocatedDefinitions.withObject(ROUTE_TEMPLATE_BEAN_DEFINITION);
-        populateDefinitions(answer, relocatedDefinitions);
-        return answer;
-    }
-
-    public ObjectNode getTemplatedRouteBean() {
-        var definitions = yamlDslSchema
-                .withObject("/items")
-                .withObject("/definitions");
-        var relocatedDefinitions = relocateToRootDefinitions(definitions);
-        var answer = relocatedDefinitions.withObject(TEMPLATED_ROUTE_BEAN_DEFINITION);
-        populateDefinitions(answer, relocatedDefinitions);
         return answer;
     }
 

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelCatalogProcessorTest.java
@@ -216,7 +216,7 @@ public class CamelCatalogProcessorTest {
 
     @Test
     public void testGetPatternCatalog() throws Exception {
-        assertTrue(processorCatalog.size() > 55 && processorCatalog.size() < 70);
+        assertTrue(processorCatalog.size() > 65 && processorCatalog.size() < 80);
         var choiceModel = processorCatalog.withObject("/choice").withObject("/model");
         assertEquals("choice", choiceModel.get("name").asText());
         var aggregateSchema = processorCatalog.withObject("/aggregate").withObject("/propertiesSchema");
@@ -259,8 +259,7 @@ public class CamelCatalogProcessorTest {
                 "templatedRoute",
                 "restConfiguration",
                 "rest",
-                "routeTemplateBean",
-                "templatedRouteBean"
+                "routeTemplateBean"
         ).forEach(name -> assertTrue(entityCatalog.has(name), name));
         var bean = entityCatalog.withObject("/bean");
         var beanScriptLanguage = bean.withObject("/propertiesSchema")
@@ -270,7 +269,7 @@ public class CamelCatalogProcessorTest {
         var beans = entityCatalog.withObject("/beans");
         var beansScript = beans.withObject("/propertiesSchema")
                 .withObject("/definitions")
-                .withObject("/org.apache.camel.model.app.RegistryBeanDefinition")
+                .withObject("/org.apache.camel.model.BeanFactoryDefinition")
                 .withObject("/properties")
                 .withObject("/script");
         assertEquals("Script", beansScript.get("title").asText());
@@ -279,11 +278,6 @@ public class CamelCatalogProcessorTest {
                 .withObject("/properties")
                 .withObject("/type");
         assertEquals("Type", routeTemplateBeanType.get("title").asText());
-        var templatedRouteBean = entityCatalog.withObject("/templatedRouteBean");
-        var templatedRouteBeanProperties = templatedRouteBean.withObject("/propertiesSchema")
-                .withObject("/properties")
-                .withObject("/properties");
-        assertEquals("Properties", templatedRouteBeanProperties.get("title").asText());
     }
 
     @Test

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/test/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessorTest.java
@@ -44,7 +44,7 @@ public class CamelYamlDslSchemaProcessorTest {
         assertEquals("array", beansSchema.get("type").asText());
         var beanSchema = beansSchema
                 .withObject("/definitions")
-                .withObject("/org.apache.camel.model.app.RegistryBeanDefinition");
+                .withObject("/org.apache.camel.model.BeanFactoryDefinition");
         var beanPropertySchema = beanSchema
                 .withObject("/properties")
                 .withObject("/properties");
@@ -165,20 +165,6 @@ public class CamelYamlDslSchemaProcessorTest {
                 "restConfiguration",
                 "rest"
         ).forEach(name -> assertTrue(entityMap.containsKey(name), name));
-    }
-
-    @Test
-    public void testGetRouteTemplateBean() {
-        var rtb = processor.getRouteTemplateBean();
-        assertNotNull(rtb);
-        assertNotNull(rtb.withObject("/definitions").withObject("/org.apache.camel.model.PropertyDefinition"));
-    }
-
-    @Test
-    public void testGetTemplatedRouteBean() {
-        var trb = processor.getTemplatedRouteBean();
-        assertNotNull(trb);
-        assertNotNull(trb.withObject("/definitions").withObject("/org.apache.camel.model.PropertyDefinition"));
     }
 
     @Test

--- a/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
@@ -70,7 +70,7 @@ describe('Test for camel route root containers configuration', () => {
     cy.get(`input[name="routeConfigurationId"]`).clear().type('test.routeConfigurationId');
     cy.get(`input[name="routePolicy"]`).clear().type('test.routePolicy');
     cy.get(`input[name="startupOrder"]`).clear().type('test.startupOrder');
-    cy.get(`input[name="streamCaching"]`).check();
+    cy.get(`input[name="streamCache"]`).check();
     cy.get(`input[name="trace"]`).check();
 
     cy.openSourceCode();
@@ -95,7 +95,7 @@ describe('Test for camel route root containers configuration', () => {
     cy.checkCodeSpanLine('routeConfigurationId: test.routeConfigurationId');
     cy.checkCodeSpanLine('routePolicy: test.routePolicy');
     cy.checkCodeSpanLine('startupOrder: test.startupOrder');
-    cy.checkCodeSpanLine('streamCaching: true');
+    cy.checkCodeSpanLine('streamCache: true');
     cy.checkCodeSpanLine('trace: true');
   });
 });

--- a/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/dataFormatStepConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/dataFormatStepConfig.cy.ts
@@ -30,12 +30,12 @@ describe('Tests for sidebar dataformat configuration', () => {
     // Configure marshal dataformat
     cy.openStepConfigurationTab('marshal');
     cy.selectDataformat('Avro');
-    cy.configureDropdownValue('library', 'Jackson');
+    cy.configureDropdownValue('library', 'avroJackson');
     cy.interactWithDataformatInputObject('unmarshalType', 'com.fasterxml.jackson.databind.JsonNode');
     cy.interactWithDataformatInputObject('schemaResolver', '#bean:{{}{{}schemaResolver}}');
     // CHECK they are reflected in the code editor
     cy.openSourceCode();
-    cy.checkCodeSpanLine('library: Jackson', 1);
+    cy.checkCodeSpanLine('library: avroJackson', 1);
     cy.checkCodeSpanLine('unmarshalType: com.fasterxml.jackson.databind.JsonNode', 1);
     cy.checkCodeSpanLine('schemaResolver: "#bean:{{schemaResolver}}"', 1);
 

--- a/packages/ui/src/components/Form/bean/BeanReferenceField.tsx
+++ b/packages/ui/src/components/Form/bean/BeanReferenceField.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import { wrapField } from '@kaoto-next/uniforms-patternfly';
-import { RegistryBeanDefinition, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
+import { BeanFactory } from '@kaoto/camel-catalog/types';
 import { NewBeanModal } from './NewBeanModal';
 import { BeansEntityHandler } from '../../../models/visualization/metadata/beans-entity-handler';
 
@@ -217,7 +217,7 @@ const BeanReferenceFieldComponent = (props: BeanReferenceFieldProps) => {
   );
 
   const handleCreateBean = useCallback(
-    (model: RegistryBeanDefinition | RouteTemplateBeanDefinition) => {
+    (model: BeanFactory) => {
       beansHandler.addNewBean(model);
 
       const beanRef = beansHandler.getReferenceFromName(model.name);

--- a/packages/ui/src/components/Form/bean/NewBeanModal.tsx
+++ b/packages/ui/src/components/Form/bean/NewBeanModal.tsx
@@ -1,4 +1,4 @@
-import { RegistryBeanDefinition } from '@kaoto/camel-catalog/types';
+import { BeanFactory } from '@kaoto/camel-catalog/types';
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { KaotoSchemaDefinition } from '../../../models';
@@ -13,7 +13,7 @@ export type NewBeanModalProps = {
   propertyTitle: string;
   javaType?: string;
   isOpen: boolean;
-  onCreateBean: (model: RegistryBeanDefinition) => void;
+  onCreateBean: (model: BeanFactory) => void;
   onCancelCreateBean: () => void;
 };
 
@@ -31,7 +31,7 @@ export const NewBeanModal: FunctionComponent<NewBeanModalProps> = (props: NewBea
     const beanModelTmp = cloneDeep(beanModel);
     const valid = await submitRef.current?.form.validate();
     if (!isDefined(valid)) {
-      props.onCreateBean(beanModelTmp as RegistryBeanDefinition);
+      props.onCreateBean(beanModelTmp as BeanFactory);
     }
   }, [beanModel, props]);
 

--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -1,4 +1,4 @@
-import { FromDefinition, Kamelet, ObjectMeta, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
+import { FromDefinition, Kamelet, ObjectMeta, BeanFactory } from '@kaoto/camel-catalog/types';
 import { SourceSchemaType } from './camel/source-schema-type';
 import { KaotoSchemaDefinition } from './kaoto-schema';
 
@@ -47,7 +47,7 @@ export interface IKameletSpec {
   definition: IKameletSpecDefinition;
   dependencies: string[];
   template: {
-    beans?: RouteTemplateBeanDefinition[];
+    beans?: BeanFactory[];
     from: FromDefinition;
   };
   types?: {

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -1,4 +1,4 @@
-import { ErrorHandlerBuilderDeserializer, NoErrorHandler } from '@kaoto/camel-catalog/types';
+import { ErrorHandlerDeserializer, NoErrorHandler } from '@kaoto/camel-catalog/types';
 import { useSchemasStore } from '../../../store';
 import { errorHandlerSchema } from '../../../stubs/error-handler';
 import { EntityType } from '../../camel/entities';
@@ -6,7 +6,7 @@ import { CamelErrorHandlerVisualEntity } from './camel-error-handler-visual-enti
 
 describe('CamelErrorHandlerVisualEntity', () => {
   const ERROR_HANDLER_ID_REGEXP = /^errorHandler-[a-zA-Z0-9]{4}$/;
-  let errorHandlerDef: { errorHandler: ErrorHandlerBuilderDeserializer };
+  let errorHandlerDef: { errorHandler: ErrorHandlerDeserializer };
 
   beforeAll(() => {
     useSchemasStore.getState().setSchema('errorHandler', {

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -1,4 +1,4 @@
-import { ErrorHandlerBuilderDeserializer, ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { ErrorHandlerDeserializer, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { SchemaService } from '../../../components/Form/schema.service';
 import { useSchemasStore } from '../../../store';
@@ -17,12 +17,12 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
   id: string;
   readonly type = EntityType.ErrorHandler;
 
-  constructor(public errorHandlerDef: { errorHandler: ErrorHandlerBuilderDeserializer } = { errorHandler: {} }) {
+  constructor(public errorHandlerDef: { errorHandler: ErrorHandlerDeserializer } = { errorHandler: {} }) {
     const id = getCamelRandomId('errorHandler');
     this.id = id;
   }
 
-  static isApplicable(errorHandlerDef: unknown): errorHandlerDef is { errorHandler: ErrorHandlerBuilderDeserializer } {
+  static isApplicable(errorHandlerDef: unknown): errorHandlerDef is { errorHandler: ErrorHandlerDeserializer } {
     if (!isDefined(errorHandlerDef) || Array.isArray(errorHandlerDef) || typeof errorHandlerDef !== 'object') {
       return false;
     }
@@ -137,7 +137,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
     return errorHandlerGroupNode;
   }
 
-  toJSON(): { errorHandler: ErrorHandlerBuilderDeserializer } {
+  toJSON(): { errorHandler: ErrorHandlerDeserializer } {
     return { errorHandler: this.errorHandlerDef.errorHandler };
   }
 }

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -11,6 +11,20 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
   "schema": {
     "additionalProperties": false,
     "definitions": {
+      "org.apache.camel.model.ErrorHandlerDefinition": {
+        "$comment": "errorhandler",
+        "additionalProperties": false,
+        "description": "Camel error handling.",
+        "properties": {
+          "id": {
+            "description": "The id of this node",
+            "title": "Id",
+            "type": "string",
+          },
+        },
+        "title": "Error Handler",
+        "type": "object",
+      },
       "org.apache.camel.model.FromDefinition": {
         "additionalProperties": false,
         "properties": {
@@ -117,6 +131,16 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "title": "Description",
         "type": "string",
       },
+      "errorHandler": {
+        "$ref": "#/definitions/org.apache.camel.model.ErrorHandlerDefinition",
+        "description": "Sets the error handler to use for this route",
+        "title": "Error Handler",
+      },
+      "errorHandlerRef": {
+        "description": "Sets the bean ref name of the error handler builder to use on this route",
+        "title": "Error Handler",
+        "type": "string",
+      },
       "from": {
         "$ref": "#/definitions/org.apache.camel.model.FromDefinition",
         "description": "From",
@@ -194,7 +218,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "title": "Startup Order",
         "type": "number",
       },
-      "streamCaching": {
+      "streamCache": {
         "description": "Whether stream caching is enabled on this route.",
         "title": "Stream Cache",
         "type": "boolean",
@@ -567,7 +591,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
   },
   "schema": {
     "additionalProperties": false,
-    "description": "Logs the defined message to the logger",
+    "description": "Used for printing custom messages to the logger.",
     "properties": {
       "description": {
         "description": "Sets the description of this node",
@@ -620,7 +644,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": "string",
       },
     },
-    "title": "Log",
+    "title": "Logger",
     "type": "object",
   },
   "title": "log",
@@ -689,7 +713,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
   },
   "schema": {
     "additionalProperties": false,
-    "description": "Logs the defined message to the logger",
+    "description": "Used for printing custom messages to the logger.",
     "properties": {
       "description": {
         "description": "Sets the description of this node",
@@ -742,7 +766,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
         "type": "string",
       },
     },
-    "title": "Log",
+    "title": "Logger",
     "type": "object",
   },
   "title": "log",

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
@@ -36,7 +36,7 @@ describe('BeansEntityHandler', () => {
       expect(beanSchema!.properties!.builderClass.title).toEqual('Builder Class');
       expect(beanSchema!.properties!.script.title).toEqual('Script');
       const beansSchema = beansHandler.getBeansSchema();
-      expect((beansSchema!.items as KaotoSchemaDefinition['schema'])['$ref']).toContain('RegistryBeanDefinition');
+      expect((beansSchema!.items as KaotoSchemaDefinition['schema'])['$ref']).toContain('BeanFactoryDefinition');
       expect(beansHandler.getBeansEntity()).toBeUndefined();
       expect(beansHandler.getBeansModel()).toBeUndefined();
     });
@@ -85,13 +85,13 @@ describe('BeansEntityHandler', () => {
       expect(model.spec.template.beans).toBeUndefined();
       expect(beansHandler.isSupported()).toBeTruthy();
       const beanSchema = beansHandler.getBeanSchema();
-      expect(beanSchema?.properties!.builderClass).toBeUndefined();
+      expect(beanSchema?.properties!.builderClass).toBeDefined();
       expect(beanSchema?.properties!.script.title).toEqual('Script');
       const beansSchema = beansHandler.getBeansSchema();
       expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.scriptLanguage.title).toEqual(
         'Script Language',
       );
-      expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.builderClass).toBeUndefined();
+      expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.builderClass).toBeDefined();
       expect(beansHandler.getBeansEntity()).toBeUndefined();
       expect(beansHandler.getBeansModel()).toBeUndefined();
     });

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -1,4 +1,4 @@
-import { BeansDeserializer, RegistryBeanDefinition, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
+import { BeansDeserializer, BeanFactory } from '@kaoto/camel-catalog/types';
 import { BeansAwareResource, CamelResource, RouteTemplateBeansAwareResource } from '../../camel';
 import { EntityType } from '../../camel/entities';
 import { CatalogKind } from '../../catalog-kind';
@@ -8,7 +8,7 @@ import { BeansEntity } from './beansEntity';
 import { RouteTemplateBeansEntity } from './routeTemplateBeansEntity';
 
 /**
- * This class is to absorb a little bit of difference between beans such as {@link RegistryBeanDefinition} and {@link RouteTemplateBeanDefinition}.
+ * This class is to absorb a little bit of difference between beans such as {@link BeanFactory}.
  */
 export class BeansEntityHandler {
   private type: 'beans' | 'routeTemplateBean' | undefined;
@@ -71,7 +71,7 @@ export class BeansEntityHandler {
     return this.getBeansEntity()?.parent.beans;
   }
 
-  setBeansModel(model: BeansDeserializer | RouteTemplateBeanDefinition[]) {
+  setBeansModel(model: BeansDeserializer | BeanFactory[]) {
     if (!Array.isArray(model) || model.length === 0) {
       const entity = this.getBeansEntity();
       entity && this.deleteBeansEntity(entity);

--- a/packages/ui/src/models/visualization/metadata/routeTemplateBeansEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/routeTemplateBeansEntity.ts
@@ -1,9 +1,9 @@
-import { RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
+import { BeanFactory } from '@kaoto/camel-catalog/types';
 import { v4 as uuidv4 } from 'uuid';
 import { EntityType, BaseCamelEntity } from '../../camel/entities';
 
 export type RouteTemplateBeansParentType = {
-  beans: Partial<RouteTemplateBeanDefinition>[];
+  beans: Partial<BeanFactory>[];
 };
 
 export class RouteTemplateBeansEntity implements BaseCamelEntity {

--- a/packages/ui/src/pages/Beans/BeansPage.tsx
+++ b/packages/ui/src/pages/Beans/BeansPage.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { EntitiesContext } from '../../providers/entities.provider';
 import { MetadataEditor } from '../../components/MetadataEditor';
 import { BeansEntityHandler } from '../../models/visualization/metadata/beans-entity-handler';
-import { BeansDeserializer, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
+import { BeansDeserializer, BeanFactory } from '@kaoto/camel-catalog/types';
 
 export const BeansPage: FunctionComponent = () => {
   const entitiesContext = useContext(EntitiesContext);
@@ -22,7 +22,7 @@ export const BeansPage: FunctionComponent = () => {
   }, [beansHandler]);
 
   const handleChangeModel = useCallback(
-    (model: BeansDeserializer | RouteTemplateBeanDefinition[]) => {
+    (model: BeansDeserializer | BeanFactory[]) => {
       beansHandler.setBeansModel(model);
       entitiesContext?.updateSourceCodeFromEntities();
     },

--- a/packages/ui/src/stubs/rest-configuration.ts
+++ b/packages/ui/src/stubs/rest-configuration.ts
@@ -64,8 +64,9 @@ export const restConfigurationSchema: KaotoSchemaDefinition['schema'] = {
     useXForwardHeaders: {
       type: 'boolean',
       title: 'Use XForward Headers',
-      description: 'Whether to use X-Forward headers for Host and related setting. The default value is true.',
-      default: true,
+      description:
+        'Whether to use X-Forward headers to set host etc. for OpenApi. This may be needed in special cases involving reverse-proxy and networking going from HTTP to HTTPS etc. Then the proxy can send X-Forward headers (X-Forwarded-Proto) that influences the host names in the OpenAPI schema that camel-openapi-java generates from Rest DSL routes.',
+      default: false,
     },
     producerApiDoc: {
       type: 'string',
@@ -83,7 +84,7 @@ export const restConfigurationSchema: KaotoSchemaDefinition['schema'] = {
       type: 'string',
       title: 'Api Context Path',
       description:
-        'Sets a leading API context-path the REST API services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path.',
+        'Sets a leading context-path the REST API will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path.',
     },
     apiContextRouteId: {
       type: 'string',
@@ -120,6 +121,12 @@ export const restConfigurationSchema: KaotoSchemaDefinition['schema'] = {
         'Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do.',
       default: false,
     },
+    bindingPackageScan: {
+      type: 'string',
+      title: 'Binding Package Scan',
+      description:
+        'Package name to use as base (offset) for classpath scanning of POJO classes are located when using binding mode is enabled for JSon or XML. Multiple package names can be separated by comma.',
+    },
     clientRequestValidation: {
       type: 'boolean',
       title: 'Client Request Validation',
@@ -144,8 +151,8 @@ export const restConfigurationSchema: KaotoSchemaDefinition['schema'] = {
       type: 'boolean',
       title: 'Inline Routes',
       description:
-        'Inline routes in rest-dsl which are linked using direct endpoints. By default, each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). Enabling this allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. This option is default false.',
-      default: false,
+        'Inline routes in rest-dsl which are linked using direct endpoints. Each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). By inlining (default) allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. If a route is not using direct endpoint then the rest-dsl is not inlined, and will become an individual route. This option is default true.',
+      default: true,
     },
     jsonDataFormat: {
       type: 'string',


### PR DESCRIPTION
- `setVariables` is added, need a little adjustment for schema/catalog comparison
- YAML DSL `streamCaching` option on RouteDefinition was aligned to `streamCache` which is used for XML/Java DSL
- `RegistryBeanDefinition` for YAML `beans` and `RouteTemplateBean` for Kamelet has been migrated to `BeanFactoryDefinition`
- `ErrorHandlerBuilderDeserializer` was migrated to `ErrorHandlerDeserializer`