### PR TITLE
Fix StepToolbar with CustomNode components

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.scss
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.scss
@@ -2,7 +2,9 @@
 
 .step-toolbar {
   @include custom.highligth {
-    display: inline-block;
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: center;
     position: relative;
     border: 1px solid var(--custom-node-BorderColor);
     border-radius: var(--custom-node-BorderRadius);
@@ -11,6 +13,7 @@
     padding: var(--pf-t--global--spacer--sm);
 
     &__button {
+      flex-shrink: 0;
       margin-right: 1rem;
     }
 

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.utils.ts
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.utils.ts
@@ -1,0 +1,92 @@
+import { NodeInteraction } from '../../../../models';
+import { CanvasDefaults } from '../canvas.defaults';
+
+export interface StepToolbarOptions {
+  nodeInteraction: NodeInteraction;
+  /** Whether the collapse toggle button is shown */
+  isCollapsible?: boolean;
+  /** Whether the duplicate button is shown (from useDuplicateStep hook) */
+  canDuplicate?: boolean;
+  /** Whether the enable-all button is shown (from useEnableAllSteps hook) */
+  areMultipleStepsDisabled?: boolean;
+}
+
+/**
+ * Counts the number of visible toolbar buttons based on node interaction and options.
+ */
+export function getVisibleToolbarButtonCount(options: StepToolbarOptions): number {
+  const { nodeInteraction, isCollapsible, canDuplicate, areMultipleStepsDisabled } = options;
+  let count = 0;
+
+  // Duplicate button
+  if (canDuplicate) {
+    count++;
+  }
+
+  // Add branch button (special children)
+  if (nodeInteraction.canHaveSpecialChildren) {
+    count++;
+  }
+
+  // Enable/Disable button
+  if (nodeInteraction.canBeDisabled) {
+    count++;
+  }
+
+  // Enable all button
+  if (areMultipleStepsDisabled) {
+    count++;
+  }
+
+  // Replace step button
+  if (nodeInteraction.canReplaceStep) {
+    count++;
+  }
+
+  // Collapse/Expand button
+  if (isCollapsible) {
+    count++;
+  }
+
+  // Delete step button
+  if (nodeInteraction.canRemoveStep) {
+    count++;
+  }
+
+  // Delete group button
+  if (nodeInteraction.canRemoveFlow) {
+    count++;
+  }
+
+  return count;
+}
+
+/**
+ * Calculates the required toolbar width based on the number of buttons.
+ * Formula: (buttonCount * buttonWidth) + ((buttonCount - 1) * margin) + (2 * padding)
+ */
+export function calculateToolbarWidth(buttonCount: number): number {
+  if (buttonCount <= 0) {
+    return 0;
+  }
+
+  const { STEP_TOOLBAR_BUTTON_WIDTH, STEP_TOOLBAR_BUTTON_MARGIN, STEP_TOOLBAR_PADDING } = CanvasDefaults;
+
+  // Total width = buttons + margins between buttons + container padding on both sides
+  const buttonsWidth = buttonCount * STEP_TOOLBAR_BUTTON_WIDTH;
+  const marginsWidth = (buttonCount - 1) * STEP_TOOLBAR_BUTTON_MARGIN;
+  const paddingWidth = 2 * STEP_TOOLBAR_PADDING;
+
+  return buttonsWidth + marginsWidth + paddingWidth;
+}
+
+/**
+ * Calculates the toolbar width ensuring it's at least as wide as the reference width (node/group).
+ * This combines the dynamic button count calculation with a minimum width constraint.
+ */
+export function getToolbarWidth(options: StepToolbarOptions, referenceWidth: number): number {
+  const buttonCount = getVisibleToolbarButtonCount(options);
+  const calculatedWidth = calculateToolbarWidth(buttonCount);
+
+  return Math.max(calculatedWidth, referenceWidth);
+}

--- a/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
@@ -19,6 +19,9 @@ export class CanvasDefaults {
 
   static readonly STEP_TOOLBAR_WIDTH = 350;
   static readonly STEP_TOOLBAR_HEIGHT = 60;
+  static readonly STEP_TOOLBAR_BUTTON_WIDTH = 36;
+  static readonly STEP_TOOLBAR_BUTTON_MARGIN = 16;
+  static readonly STEP_TOOLBAR_PADDING = 16;
 
   static readonly HOVER_DELAY_IN = 200;
   static readonly HOVER_DELAY_OUT = 500;

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -30,9 +30,11 @@ import { IconResolver } from '../../../IconResolver';
 import { LayoutType } from '../../Canvas';
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { StepToolbar } from '../../Canvas/StepToolbar/StepToolbar';
+import { getToolbarWidth } from '../../Canvas/StepToolbar/StepToolbar.utils';
 import { customGroupExpandedDropTargetSpec } from '../customComponentUtils';
 import { AddStepIcon } from '../Edge/AddStepIcon';
 import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
+import { useEnableAllSteps } from '../hooks/enable-all-steps.hook';
 import { TargetAnchor } from '../target-anchor';
 import { CustomGroupProps } from './Group.models';
 
@@ -56,6 +58,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
       CanvasDefaults.HOVER_DELAY_OUT,
     );
     const boxRef = useRef<Rect | null>(null);
+    const { areMultipleStepsDisabled } = useEnableAllSteps();
     const shouldShowToolbar =
       settingsAdapter.getSettings().nodeToolbarTrigger === NodeToolbarTrigger.onHover
         ? isGHover || isToolbarHover || selected
@@ -76,7 +79,18 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
       boxRef.current = element.getBounds();
     }
 
-    const toolbarWidth = Math.max(CanvasDefaults.STEP_TOOLBAR_WIDTH, boxRef.current.width);
+    const nodeInteraction = vizNode.getNodeInteraction();
+    // Use canHaveNextStep as a heuristic for canDuplicate since the actual value
+    // depends on catalog compatibility checks that are expensive to compute here
+    const toolbarWidth = getToolbarWidth(
+      {
+        nodeInteraction,
+        isCollapsible: !!onCollapseToggle,
+        canDuplicate: nodeInteraction.canHaveNextStep,
+        areMultipleStepsDisabled,
+      },
+      boxRef.current.width,
+    );
     const toolbarX = boxRef.current.x + (boxRef.current.width - toolbarWidth) / 2;
     const toolbarY = boxRef.current.y - CanvasDefaults.STEP_TOOLBAR_HEIGHT;
     const addStepX = isHorizontal


### PR DESCRIPTION
…e buttons

The StepToolbar was overflowing horizontally when nodes had multiple available actions, causing buttons to wrap to multiple rows instead of displaying in a single row.

This fix:
- Adds constants for toolbar button dimensions in canvas.defaults.ts
- Creates a utility function to calculate toolbar width based on the number of visible buttons
- Updates CustomNode and CustomGroupExpanded to use dynamic width calculation that compares against the node/group width
- Updates StepToolbar.scss to use flexbox with nowrap to prevent button wrapping

Fixes #2425