### PR TITLE
refactor(datamapper): convert processTreeNode from BFS to recursive DFS

### DIFF
--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -62,22 +62,19 @@ describe('useDocumentTreeStore', () => {
       const keys = Object.keys(state[tree.documentId]);
 
       expect(keys).toEqual([
+        // DFS order: Root -> ShipOrder -> children -> grandchildren (maxFields extends beyond maxDepth)
         'targetBody:Body://',
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-OrderId-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-OrderPerson-\d{4}$/),
-
-        // ShipTo
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}$/),
-
-        // Item
-        expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}$/),
-
+        // ShipTo children (depth-first: complete this subtree before moving to Item)
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-Name-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-Address-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-City-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-Country-\d{4}$/),
-
+        // Item and its children
+        expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Title-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Note-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Quantity-\d{4}$/),

--- a/packages/ui/src/utils/process-tree-node.test.ts
+++ b/packages/ui/src/utils/process-tree-node.test.ts
@@ -35,19 +35,19 @@ describe('processTreeNodeToDepth', () => {
 
     expect(processedNodePaths).toHaveLength(14);
     expect(processedNodePaths).toEqual([
-      //
+      // DFS order: Root -> ShipOrder -> children -> grandchildren (maxFields extends beyond maxDepth)
       'targetBody:Body://',
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-OrderId-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-OrderPerson-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}$/),
-      expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}$/),
-
+      // ShipTo children (depth-first: complete this subtree before moving to Item)
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-Name-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-Address-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-City-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-ShipTo-\d{4}\/fx-Country-\d{4}$/),
-
+      // Item and its children
+      expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Title-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Note-\d{4}$/),
       expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Quantity-\d{4}$/),
@@ -67,7 +67,7 @@ describe('processTreeNodeToDepth', () => {
       processedNodePaths.push(treeNode.path);
     });
 
-    expect(processedNodePaths).toHaveLength(107);
+    expect(processedNodePaths).toHaveLength(177);
   });
 
   it('should not throw an error when processing beyond the DocumentTree parsed level', () => {
@@ -88,24 +88,25 @@ describe('processTreeNodeToDepth', () => {
     expect(processedNodePaths).toHaveLength(14);
   });
 
-  it('should stop processing when reaching the max fields count', () => {
-    targetDoc = TestUtil.createCamelSpringXsdSourceDoc();
-    targetDocNode = new DocumentNodeData(targetDoc);
-    tree = new DocumentTree(targetDocNode);
-    const processedNodePaths: string[] = [];
+  it('should use maxFields to extend traversal beyond maxDepth', () => {
+    const processedWithFields: string[] = [];
+    const processedDepthOnly: string[] = [];
     TreeParsingService.parseTree(tree);
 
-    const fn = () => {
-      processTreeNode(
-        tree.root,
-        (treeNode) => {
-          processedNodePaths.push(treeNode.path);
-        },
-        { maxDepth: Number.MAX_SAFE_INTEGER },
-      );
-    };
+    // With default maxFields=100, nodes beyond maxDepth are still visited
+    processTreeNode(tree.root, (treeNode) => {
+      processedWithFields.push(treeNode.path);
+    });
 
-    expect(fn).not.toThrow();
-    expect(processedNodePaths).toHaveLength(3517);
+    // With maxFields=0, only maxDepth is respected (no extension)
+    processTreeNode(
+      tree.root,
+      (treeNode) => {
+        processedDepthOnly.push(treeNode.path);
+      },
+      { maxFields: 0 },
+    );
+
+    expect(processedWithFields.length).toBeGreaterThan(processedDepthOnly.length);
   });
 });

--- a/packages/ui/src/utils/process-tree-node.ts
+++ b/packages/ui/src/utils/process-tree-node.ts
@@ -2,7 +2,8 @@ import { INITIAL_FIELD_COUNTS, INITIAL_PARSE_DEPTH } from '../models/datamapper/
 import { DocumentTreeNode } from '../models/datamapper/document-tree-node';
 
 /**
- * Process on a tree node and its children up to the specified depth
+ * Process a tree node and its children up to the specified depth.
+ * maxDepth is the guaranteed minimum depth, maxFields allows extending beyond it.
  */
 export const processTreeNode = (
   treeNode: DocumentTreeNode,
@@ -14,35 +15,22 @@ export const processTreeNode = (
 ): void => {
   const { maxDepth = INITIAL_PARSE_DEPTH, maxFields = INITIAL_FIELD_COUNTS } = options;
 
-  // Use a queue for breadth-first traversal
-  const queue: Array<{ node: DocumentTreeNode; depth: number; count: number }> = [
-    { node: treeNode, depth: 0, count: 0 },
-  ];
-
   let totalFieldsProcessed = 0;
 
-  while (queue.length > 0) {
-    const { node, depth, count } = queue.shift()!;
-
-    if ((depth >= maxDepth && count >= maxFields) || node.nodeData.isPrimitive) {
-      continue;
+  const visit = (node: DocumentTreeNode, depth: number): void => {
+    if ((depth >= maxDepth && totalFieldsProcessed >= maxFields) || node.nodeData.isPrimitive) {
+      return;
     }
 
+    totalFieldsProcessed++;
     fn(node);
 
     for (const childTreeNode of node.children) {
-      const nextDepth = depth + 1;
-      const nextFieldsCount = count + 1;
-
-      totalFieldsProcessed++;
-
-      if (nextDepth < maxDepth || totalFieldsProcessed < maxFields) {
-        queue.push({
-          node: childTreeNode,
-          depth: nextDepth,
-          count: nextFieldsCount,
-        });
+      if (depth + 1 < maxDepth || totalFieldsProcessed < maxFields) {
+        visit(childTreeNode, depth + 1);
       }
     }
-  }
+  };
+
+  visit(treeNode, 0);
 };


### PR DESCRIPTION
## Summary
- Replace breadth-first (queue + shift) with depth-first recursion in `processTreeNode`
- Update test expectations for DFS traversal order and node counts